### PR TITLE
fix(configuration): simple server URL promoted as default

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -51,7 +51,7 @@ Available parameters
 
 The only required configuration parameter is an execution target, which depends on the mode you will use:
 
-* ``server``: a server URL, such as ``https://glpi/front/inventory.php``,
+* ``server``: a server URL, such as ``https://my-glpi-server/``, or ``https://my-glpi-server/front/inventory.php``,
 * ``local``: full path for local directory, like ``/tmp/inventory``.
 
 .. _server:
@@ -67,21 +67,21 @@ The only required configuration parameter is an execution target, which depends 
 
    * If you're using **GLPI 9.5.x** with **FusionInventory for GLPI plugin 9.5+3.0**:
 
-    Your server URL should look like: ``https://glpi-server/plugins/fusioninventory/``
+    Your server URL should look like: ``https://my-glpi-server/plugins/fusioninventory/``
 
    * If you're using `GLPI 10+ <https://glpi10.com/>`_, there are few cases regarding `GlpiInventory plugin <https://plugins.glpi-project.org/#/plugin/glpiinventory>`_ usage:
 
     1. If you're not using **GlpiInventory plugin**:
 
-     Your server URL should look like: ``https://glpi-server/``
+     Your server URL should look like: ``https://my-glpi-server/``, or ``https://my-glpi-server/front/inventory.php``
 
     2. If you have installed **GlpiInventory plugin** via **Marketplace**:
 
-     Your server URL should look like: ``https://glpi-server/marketplace/glpiinventory/``
+     Your server URL should look like: ``https://my-glpi-server/marketplace/glpiinventory/``
 
     3. If you have installed **GlpiInventory plugin** manually under ``/plugins`` GLPI folder:
 
-     Your server URL should look like: ``https://glpi-server/plugins/glpiinventory/``
+     Your server URL should look like: ``https://my-glpi-server/plugins/glpiinventory/``
 
 ``server``
     Specifies the server to use both as a controller for the agent, and as a

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -96,7 +96,7 @@ After installation, you can easily configure the agent with the **set** ``snap``
 
 .. prompt:: bash
 
-   snap set glpi-agent server=http://myserver/front/inventory.php
+   snap set glpi-agent server=http://my-glpi-server/
 
 Any supported glpi-agent option can be set this way. If you need to unset a configuration parameter, just set it empty:
 

--- a/source/man/glpi-agent.rst
+++ b/source/man/glpi-agent.rst
@@ -137,19 +137,19 @@ Target definition options
 
    ::
 
-          % --server=http://example/front/inventory.php
+          % --server=http://my-glpi-server/
 
    In general, GLPI server URL have this format:
 
    ::
 
-          http://example/front/inventory.php
+          http://my-glpi-server/
 
    and FusionInventory for GLPI this one:
 
    ::
 
-          http://example/glpi/plugins/fusioninventory
+          http://my-glpi-server/plugins/fusioninventory
 
    Multiple values can be specified, using comma as a separator.
 

--- a/source/plugins/proxy-server-plugin.rst
+++ b/source/plugins/proxy-server-plugin.rst
@@ -226,7 +226,7 @@ Finally, inject inventories into GLPI with ``glpi-injector`` script:
 
 .. prompt:: bash
 
-   glpi-injector -d /var/glpi-agent -r -R -u http://glpi-server/front/inventory.php
+   glpi-injector -d /var/glpi-agent -r -R -u http://my-glpi-server/
 
 Proxy with HTTP and HTTPS support
 """""""""""""""""""""""""""""""""


### PR DESCRIPTION
I think that ```http://my-glpi-server/``` server URL is more simple for administrators, therefore I propose to display it by default in the documentation.

This does not prevent always offering ```/front/inventory.php```, nor keeping the (temporary) specificities related to the plugin fork.