### PR TITLE
Improve ssl-keystore documentation

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -250,15 +250,14 @@ The only required configuration parameter is an execution target, which depends 
 .. _ssl-keystore:
 
 ``ssl-keystore`` (Available since GLPI Agent v1.11)
-    This option is only usable on Windows or MacOSX.
-
-    Keystore support on Windows and Keychain support on MacOSX are enabled by default
-    to provide a way to authentify SSL GLPI server if CA certificate or server certificate
-    is integrated there.
+    Keystore support on Windows, Keychain support on MacOSX and CA trust store support on Unix/Linux 
+    are enabled by default to provide a way to authentify SSL GLPI server if CA certificate or server 
+    certificate is integrated there. The default CA bundle from Mozilla's is always included if the
+    Mozilla::CA CPAN module is installed. (this support case is available since GLPI Agent v1.12)
 
     It takes as argument a string which can be a list separated by commas:
 
-    * ``none``: just disable keystore support on Windows or keychain support on MacOSX
+    * ``none``: just disable Mozilla::CA bundle and keystore support on Windows, keychain support on MacOSX or CA trust store on Unix/Linux.
     * Only on Windows, any combination of the following **case-sensitive** keys:
 
       * ``My``, ``CA``, ``Root`` for default machine store
@@ -267,10 +266,11 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
-    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise root (user) and system keychains will be used.
-
-    By default, only ``CA`` and ``Root`` keystores for the machine's default, user, service, enterprise and 
+    By default, only ``CA`` and ``Root`` keystores for the machine's default, user ('LocalSystem' as a service), service, enterprise and 
     group policy stores are exported on Windows.
+
+    Only on MacOSX, the user ('root' as a daemon) and system keychains will be used.
+    On Unix/Linux, the agent uses the OpenSSL CA trust store (/etc/ssl/certs/ca-certificates.crt). (this option in not supported until v1.12)
 
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
     and `security find-certificates command <https://ss64.com/mac/security-find-cert.html>`_ to extract certificates from related store.

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -267,13 +267,13 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
-    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise a personal keychain is used.
+    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise all keychains will be used.
 
-    By default, only ``CA`` and ``Root`` keystores from machine's default, user, service, enterprise and 
+    By default, only ``CA`` and ``Root`` keystores for the machine's default, user, service, enterprise and 
     group policy stores are exported on Windows.
 
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
-    to extract certificates from related store.
+    and `security find-certificates command <https://ss64.com/mac/security-find-cert.html>`_ to extract certificates from related store.
 
 .. _no-ssl-check:
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -267,6 +267,11 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
+    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise a personal keychain is used.
+
+    By default, only ``CA`` and ``Root`` keystores from machine's default, user, service, enterprise and 
+    group policy stores are exported on Windows.
+
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
     to extract certificates from related store.
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -257,7 +257,7 @@ The only required configuration parameter is an execution target, which depends 
 
     It takes as argument a string which can be a list separated by commas:
 
-    * ``none``: just disable Mozilla::CA bundle and keystore support on Windows, keychain support on MacOSX or CA trust store on Unix/Linux.
+    * ``none``: just disable keystore support on Windows, keychain support on MacOSX or CA trust store on Unix/Linux.
     * Only on Windows, any combination of the following **case-sensitive** keys:
 
       * ``My``, ``CA``, ``Root`` for default machine store

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -252,8 +252,8 @@ The only required configuration parameter is an execution target, which depends 
 ``ssl-keystore`` (Available since GLPI Agent v1.11)
     Keystore support on Windows, Keychain support on MacOSX and CA trust store support on Unix/Linux 
     are enabled by default to provide a way to authentify SSL GLPI server if CA certificate or server 
-    certificate is integrated there. The default CA bundle from Mozilla's is always included if the
-    Mozilla::CA CPAN module is installed. (this support case is available since GLPI Agent v1.12)
+    certificate is integrated there. The default CA bundle from Mozilla's will be included only if the
+    GLPI-Agent is unable to extract certificates from the operating system. (this support case is available since GLPI Agent v1.12)
 
     It takes as argument a string which can be a list separated by commas:
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -250,14 +250,15 @@ The only required configuration parameter is an execution target, which depends 
 .. _ssl-keystore:
 
 ``ssl-keystore`` (Available since GLPI Agent v1.11)
-    Keystore support on Windows, Keychain support on MacOSX and CA trust store support on Unix/Linux 
-    are enabled by default to provide a way to authentify SSL GLPI server if CA certificate or server 
-    certificate is integrated there. The default CA bundle from Mozilla's will be included only if the
-    GLPI-Agent is unable to extract certificates from the operating system. (this support case is available since GLPI Agent v1.12)
+    This option is only usable on Windows or MacOSX.
+
+    Keystore support on Windows and Keychain support on MacOSX are enabled by default
+    to provide a way to authentify SSL GLPI server if CA certificate or server certificate
+    is integrated there.
 
     It takes as argument a string which can be a list separated by commas:
 
-    * ``none``: just disable keystore support on Windows, keychain support on MacOSX or CA trust store on Unix/Linux.
+    * ``none``: just disable keystore support on Windows or keychain support on MacOSX
     * Only on Windows, any combination of the following **case-sensitive** keys:
 
       * ``My``, ``CA``, ``Root`` for default machine store

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -266,13 +266,11 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
-    * Only on MacOSX, the user ('root' as a daemon) keychain will be used. You can use only the system keychain by using the ``system-ssl-ca`` key. (this option in not supported until v1.12)
+    * Only on MacOSX, the user ('root' as a daemon) keychain will be used.
 
-    By default, only ``CA`` and ``Root`` keystores for the machine's default, user ('LocalSystem' as a service), service, enterprise and 
-    group policy stores are exported on Windows.
+      * You can force to use the system SSL CA keychain by using the ``system-ssl-ca`` key (Available since GLPI Agent v1.12)
 
-    On Unix/Linux, the agent uses the OpenSSL CA trust store (/etc/ssl/certs/ca-certificates.crt). (this option in not supported until v1.12)
-
+    This can help if your certificate authority is not known by glpi-agent default SSL store based on `Mozilla::CA <https://metacpan.org/pod/Mozilla::CA>`_ but it is by system SSL CA.
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
     and `security find-certificates command <https://ss64.com/mac/security-find-cert.html>`_ to extract certificates from related store.
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -276,6 +276,8 @@ The only required configuration parameter is an execution target, which depends 
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
     and `security find-certificates command <https://ss64.com/mac/security-find-cert.html>`_ to extract certificates from related store.
 
+    This option cannot be used with ``ca-cert-dir``, ``ca-cert-file`` and ``ssl-fingerprint`` options.
+
 .. _no-ssl-check:
 
 ``no-ssl-check``

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -276,7 +276,7 @@ The only required configuration parameter is an execution target, which depends 
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_
     and `security find-certificates command <https://ss64.com/mac/security-find-cert.html>`_ to extract certificates from related store.
 
-    This option cannot be used with ``ca-cert-dir``, ``ca-cert-file`` and ``ssl-fingerprint`` options.
+    This option will be ignored if used at the same time than one of ``ca-cert-dir``, ``ca-cert-file`` or ``ssl-fingerprint`` options.
 
 .. _no-ssl-check:
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -266,10 +266,11 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
+    * Only on MacOSX, the user ('root' as a daemon) keychain will be used. You can use only the system keychain by using the ``system-ssl-ca`` key. (this option in not supported until v1.12)
+
     By default, only ``CA`` and ``Root`` keystores for the machine's default, user ('LocalSystem' as a service), service, enterprise and 
     group policy stores are exported on Windows.
 
-    Only on MacOSX, the user ('root' as a daemon) and system keychains will be used.
     On Unix/Linux, the agent uses the OpenSSL CA trust store (/etc/ssl/certs/ca-certificates.crt). (this option in not supported until v1.12)
 
     GLPI-Agent will use `certutil command <https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil>`_

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -267,7 +267,7 @@ The only required configuration parameter is an execution target, which depends 
       * ``Enterprise-My``, ``Enterprise-CA``, ``Enterprise-Root`` for machine enterprise store
       * ``GroupPolicy-My``, ``GroupPolicy-CA``, ``GroupPolicy-Root`` for machine group policy store
 
-    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise all keychains will be used.
+    * Only on MacOSX, you can specify multiple keychain filepaths, otherwise root (user) and system keychains will be used.
 
     By default, only ``CA`` and ``Root`` keystores for the machine's default, user, service, enterprise and 
     group policy stores are exported on Windows.


### PR DESCRIPTION
Please commit this only when/if https://github.com/glpi-project/glpi-agent/pull/824/files is merged and GLPI-Agent 1.12 is released. This commit also states which keystores are loaded by default from Windows and macOS builds.
Edit: https://github.com/glpi-project/glpi-agent/pull/824/files has been merged so this PR is now definitive and describes the current behavior of ``ssl-keystore`` function.