### PR TITLE
Itemtype parameters

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -461,6 +461,7 @@ Task-specific parameters
     Itemtype can only be set when generating a JSON inventory.
 
     This directive is used for inventory and remoteinventory tasks only.
+
 .. note::
 
     The suffix ``Asset`` must always be added at the end of the class name to avoid conflicts with PHP reserved keywords.

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -456,11 +456,15 @@ Task-specific parameters
     By default, it is empty and itemtype will still be set to ``Computer`` to keep compatibility with GLPI 10.
 
     The itemtype must be supported in GLPI 11+ or inventory import will be refused. When itemtype in GLPI is, as example, ``Server``,
-    ``itemtype`` value in glpi-agent must be set to ``\Glpi\CustomAsset\Server``.
+    ``itemtype`` value in glpi-agent must be set to ``\Glpi\CustomAsset\ServerAsset``.
 
     Itemtype can only be set when generating a JSON inventory.
 
     This directive is used for inventory and remoteinventory tasks only.
+.. note::
+
+    The suffix ``Asset`` must always be added at the end of the class name to avoid conflicts with PHP reserved keywords.
+
 
 .. _additional-content:
 

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -456,7 +456,7 @@ Task-specific parameters
     By default, it is empty and itemtype will still be set to ``Computer`` to keep compatibility with GLPI 10.
 
     The itemtype must be supported in GLPI 11+ or inventory import will be refused. When itemtype in GLPI is, as example, ``Server``,
-    ``itemtype`` value in glpi-agent must be set to ``\Glpi\CustomAsset\ServerAsset``.
+    ``itemtype`` value in glpi-agent must be set to ``Glpi\CustomAsset\ServerAsset``.
 
     Itemtype can only be set when generating a JSON inventory.
 

--- a/source/man/glpi-agent.rst
+++ b/source/man/glpi-agent.rst
@@ -317,7 +317,7 @@ Inventory task specific options
    a target supporting genericity, like GLPI 11+.
 
    When expected asset itemtype in GLPI 11+ is **Server**, *itemtype*
-   option value must be set to **Glpi/CustomAsset/Server**.
+   option value must be set to **Glpi\\CustomAsset\\Server**.
 
 **--scan-homedirs**
    Allow the agent to scan home directories for virtual machines.
@@ -352,7 +352,7 @@ ESX task specific options
 
    When expected ESX asset itemtype in GLPI 11+ is **Esx**,
    *esx-itemtype* option value must be set to
-   **Glpi/CustomAsset/Esx**.
+   **Glpi\\CustomAsset\\Esx**.
 
 Package deployment task specific options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/man/glpi-agent.rst
+++ b/source/man/glpi-agent.rst
@@ -316,8 +316,12 @@ Inventory task specific options
    Allow to set JSON inventory itemtype to *TYPE*. This feature requires
    a target supporting genericity, like GLPI 11+.
 
-   When expected asset itemtype in GLPI 11+ is **Server**, *itemtype*
-   option value must be set to **Glpi\\CustomAsset\\Server**.
+   When the expected asset itemtype in GLPI 11+ is **Server**, *itemtype*
+   option value must be set to **Glpi\\CustomAsset\\ServerAsset**.
+
+.. note::
+
+    The suffix ``Asset`` must always be added at the end of the class name to avoid conflicts with PHP reserved keywords.
 
 **--scan-homedirs**
    Allow the agent to scan home directories for virtual machines.

--- a/source/man/glpi-agent.rst
+++ b/source/man/glpi-agent.rst
@@ -317,7 +317,7 @@ Inventory task specific options
    a target supporting genericity, like GLPI 11+.
 
    When expected asset itemtype in GLPI 11+ is **Server**, *itemtype*
-   option value must be set to **\\Glpi\\CustomAsset\\Server**.
+   option value must be set to **Glpi/CustomAsset/Server**.
 
 **--scan-homedirs**
    Allow the agent to scan home directories for virtual machines.
@@ -352,7 +352,7 @@ ESX task specific options
 
    When expected ESX asset itemtype in GLPI 11+ is **Esx**,
    *esx-itemtype* option value must be set to
-   **\\Glpi\\CustomAsset\\Esx**.
+   **Glpi/CustomAsset/Esx**.
 
 Package deployment task specific options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/man/glpi-agent.rst
+++ b/source/man/glpi-agent.rst
@@ -356,7 +356,7 @@ ESX task specific options
 
    When expected ESX asset itemtype in GLPI 11+ is **Esx**,
    *esx-itemtype* option value must be set to
-   **Glpi\\CustomAsset\\Esx**.
+   **Glpi\\CustomAsset\\EsxAsset**.
 
 Package deployment task specific options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When trying to install GLPI Agent using Parameters, I realized the \ before Glpi\CustomAssets\Servers is not needed. So I changed them on documentation.

It solves #15 