### PR TITLE
docs: add Homebrew formula for macOS installation

### DIFF
--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -165,6 +165,17 @@ You can for example create a ``local.cfg`` file and:
 
    A MacOSX installation video tutorial is available here: `GLPI Agent Demonstration - macOS Monterey - Apple M1 <https://www.youtube.com/watch?v=zFYcURQNh9k>`_
 
+Homebrew
+^^^^^^^^
+
+You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using a community-maintained tap:
+
+.. prompt:: bash
+
+   brew tap eduardomozart/glpi-agent
+   brew trust eduardomozart/glpi-agent
+   brew install --cask glpi-agent
+
 GNU/Linux
 ---------
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -168,13 +168,21 @@ You can for example create a ``local.cfg`` file and:
 Unofficial Homebrew method
 ^^^^^^^^
 
-You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using `a community-maintained tap <https://github.com/eduardomozart/homebrew-glpi-agent>`:
+You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using `a community-maintained tap <https://github.com/eduardomozart/homebrew-glpi-agent>`_:
 
 .. prompt:: bash
 
    brew tap eduardomozart/glpi-agent
    brew trust eduardomozart/glpi-agent
    brew install --cask glpi-agent
+
+If you want to test the latest features and bug fixes from the ``develop`` branch, you can install the `nightly build <https://nightly.glpi-project.org/glpi-agent/>`_.
+
+.. prompt:: bash
+
+   brew tap eduardomozart/glpi-agent
+   brew trust eduardomozart/glpi-agent
+   brew install --cask glpi-agent-nightly
 
 GNU/Linux
 ---------

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -168,7 +168,7 @@ You can for example create a ``local.cfg`` file and:
 Unofficial Homebrew method
 ^^^^^^^^
 
-You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using a community-maintained tap:
+You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using `a community-maintained tap <https://github.com/eduardomozart/homebrew-glpi-agent>`:
 
 .. prompt:: bash
 

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -165,7 +165,7 @@ You can for example create a ``local.cfg`` file and:
 
    A MacOSX installation video tutorial is available here: `GLPI Agent Demonstration - macOS Monterey - Apple M1 <https://www.youtube.com/watch?v=zFYcURQNh9k>`_
 
-Homebrew
+Unofficial Homebrew method
 ^^^^^^^^
 
 You can also use `Homebrew <https://brew.sh/>`_ to install GLPI Agent using a community-maintained tap:


### PR DESCRIPTION
## Description
This PR updates the macOS installation documentation to include instructions for installing the GLPI Agent using [Homebrew](https://brew.sh/). It references a community-maintained tap and provides the necessary terminal commands to streamline the installation process for macOS users.

## Changes Made
- Added a new **Homebrew** subsection under the macOS installation guide in `source/installation/index.rst`.